### PR TITLE
add "domain" to auto_accessors

### DIFF
--- a/requires.py
+++ b/requires.py
@@ -27,7 +27,7 @@ class KeystoneRequires(RelationBase):
                       'credentials_project', 'credentials_username',
                       'credentials_password', 'credentials_project_id',
                       'api_version', 'auth_host', 'auth_protocol', 'auth_port',
-                      'region', 'ca_cert', 'https_keystone']
+                      'region', 'domain', 'ca_cert', 'https_keystone']
 
     @hook('{requires:keystone-credentials}-relation-joined')
     def joined(self):


### PR DESCRIPTION
This is needed for keystone v3 - at least it was needed in charm we use which embeds a forks of this interface. Unsure this is the best/right fix, please double-check.

The keystone:identity-credentials relation with 18.02 charms does return a "domain" key.

Thanks !