### PR TITLE
Remove nonexistent methods from provides.py

### DIFF
--- a/provides.py
+++ b/provides.py
@@ -20,11 +20,11 @@ class KeystoneProvides(RelationBase):
 
     @hook('{provides:keystone-credentials}-relation-joined')
     def joined(self):
-        self.set_flag('{relation_name}.connected')
+        self.set_state('{relation_name}.connected')
 
     @hook('{provides:keystone-credentials}-relation-{broken,departed}')
     def departed(self):
-        self.clear_flag('{relation_name}.connected')
+        self.remove_state('{relation_name}.connected')
 
     def expose_credentials(self, credentials):
         """Expose Keystone credentials to related units.


### PR DESCRIPTION
Methods set_flag and clear_flag are not defined
in the RelationBase class. This throws error when
calling joined and departed methods.
Nonexistent methods have been substituted with the
set_state and remove_state methods, respectively.

Closes-Bug: #1914650

